### PR TITLE
bugfixes for 2 special cases

### DIFF
--- a/src/assets/decompiler.ts
+++ b/src/assets/decompiler.ts
@@ -168,7 +168,7 @@ export function interpret(binarycode: string): string {
     }
 
     if(!inst.enS && !inst.mbr && !inst.mar && !inst.ms) {
-        s += a + "; "
+        decompiled += rightSide + "; "
     }
 
     switch(inst.cond) {


### PR DESCRIPTION
# Micro16 Decompiler Bugfixes

- fixed the case were you just pass one register through the ALU for jumps (e.g.: `R0; if Z goto 1` or `1; if Z goto 1`)
- fixed the case were you just pass a calculation between to registers through the ALU for jumps (e.g.: `R10 + R9; if N goto 4`) 

![image](https://user-images.githubusercontent.com/15055567/105382045-f7683a80-5c0f-11eb-856d-915a642a652a.png)
![image](https://user-images.githubusercontent.com/15055567/105382014-ef0fff80-5c0f-11eb-8765-de0e1965012e.png)
